### PR TITLE
fix: display form field description even when validation state is invalid

### DIFF
--- a/src/lib/core/ui/HelpText/HelpText.module.css
+++ b/src/lib/core/ui/HelpText/HelpText.module.css
@@ -11,6 +11,10 @@
 
   &[data-validation-state='invalid'] {
     color: var(--color-negative-600);
+
+    & [data-help-text] {
+      color: var(--color-neutral-600);
+    }
   }
 
   &[data-disabled] {

--- a/src/lib/core/ui/HelpText/HelpText.tsx
+++ b/src/lib/core/ui/HelpText/HelpText.tsx
@@ -38,10 +38,17 @@ export const HelpText = forwardRef(function HelpText(
       {isErrorMessage ? (
         <Fragment>
           {showErrorIcon === true ? <Icon icon={AlertIcon} /> : null}
-          <div {...errorMessageProps}>{errorMessage}</div>
+          <div {...errorMessageProps} data-error-message>
+            {errorMessage}
+          </div>
+          <div {...descriptionProps} data-help-text>
+            {description}
+          </div>
         </Fragment>
       ) : (
-        <div {...descriptionProps}>{description}</div>
+        <div {...descriptionProps} data-help-text>
+          {description}
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
closes #124

when a form field has validation state "invalid", we now display both the field error message, as well as the field description (help text)