### PR TITLE
fix: validate youtube links in media upload form

### DIFF
--- a/src/data/sshoc/validation-schemas/media.ts
+++ b/src/data/sshoc/validation-schemas/media.ts
@@ -60,3 +60,13 @@ export const mediaUploadSchema =
         params: { mediaInput: ['file', 'url'] },
       },
     )
+    .refine(
+      (data) => {
+        if (data.sourceUrl != null && data.sourceUrl.includes('youtube.com/watch')) return false
+        return true
+      },
+      {
+        message: 'Provide a youtube embed link, not a youtube watch link',
+        path: ['sourceUrl'],
+      },
+    )


### PR DESCRIPTION
this ensures that users enter youtube embed links, and don't paste youtube.com/watch links in the media upload form.

closes #161