### PR TITLE
style: adjust landing page breakpoint

### DIFF
--- a/src/components/common/ItemCategoryBadge.module.css
+++ b/src/components/common/ItemCategoryBadge.module.css
@@ -3,6 +3,7 @@
   padding: 0 var(--space-2-5);
   border-radius: 9999px;
   font-size: var(--font-size-ui-xs);
+  line-height: 1.75;
 }
 
 .dataset {

--- a/src/components/common/ItemCategoryBadge.tsx
+++ b/src/components/common/ItemCategoryBadge.tsx
@@ -1,3 +1,5 @@
+import cx from 'clsx'
+
 import css from '@/components/common/ItemCategoryBadge.module.css'
 import type { ItemCategoryWithWorkflowStep } from '@/data/sshoc/api/item'
 import { useI18n } from '@/lib/core/i18n/useI18n'
@@ -12,7 +14,5 @@ export function ItemCategoryBadge(props: ItemCategoryBadgeProps): JSX.Element {
 
   const label = t(['common', 'item-categories', category, 'one'])
 
-  const className = `${css['badge']} ${css[category]}`
-
-  return <span className={className}>{label}</span>
+  return <span className={cx(css['badge'], css[category])}>{label}</span>
 }

--- a/src/components/home/HomeScreenLayout.module.css
+++ b/src/components/home/HomeScreenLayout.module.css
@@ -34,7 +34,7 @@
       '. . funding-notice funding-notice funding-notice funding-notice funding-notice funding-notice funding-notice funding-notice . . . .';
   }
 
-  @media (/* --screen-lg */ min-width: 64rem) {
+  @media (/* --screen-xl */ min-width: 80rem) {
     grid-template-areas:
       '. . . hero hero hero hero hero hero hero hero . . .'
       '. . recommended-items recommended-items recommended-items recommended-items recommended-items recommended-items recommended-items last-updated-items last-updated-items last-updated-items . .'


### PR DESCRIPTION
this adjusts the css media queries for the landing page layout to switch the "see what's new" section from a stacking layout to a side column only above 80rem (instead of currently 60rem).

also decreases icon category badge line-height slightly.