### PR TITLE
fix: add link to commonmark website to description field helptext

### DIFF
--- a/src/components/item-form/useItemFormFields.tsx
+++ b/src/components/item-form/useItemFormFields.tsx
@@ -39,7 +39,13 @@ export function useItemFormFields(prefix = '') {
       description: {
         name: `${prefix}description`,
         label: t(['authenticated', 'fields', 'description', 'label']),
-        description: t(['authenticated', 'fields', 'description', 'description']),
+        description: t(['authenticated', 'fields', 'description', 'description'], {
+          components: {
+            Link(props) {
+              return <a href="https://commonmark.org/help/">{props.children}</a>
+            },
+          },
+        }),
         isRequired: true,
       },
       accessibleAt: {

--- a/src/dictionaries/authenticated/en.ts
+++ b/src/dictionaries/authenticated/en.ts
@@ -78,7 +78,8 @@ export const dictionary: Dictionary = {
     },
     description: {
       label: 'Description',
-      description: 'Should be concise and raise interest in the entry. Allows Markdown content.',
+      description:
+        'Should be concise and raise interest in the entry. Allows <Link>Markdown</Link> content.',
     },
     accessibleAt: {
       label: { one: 'Accessible at URL', other: 'Accessible at' },


### PR DESCRIPTION
closes #166

this adds a link to the commonmark spec and tutorial to the `description` field help text.