### PR TITLE
fix: display user email on account page

### DIFF
--- a/src/components/account/AccountHelpText.module.css
+++ b/src/components/account/AccountHelpText.module.css
@@ -1,4 +1,22 @@
+.lead {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--space-4);
+}
+
 .text {
   max-width: var(--size-192);
   line-height: var(--line-height-relaxed);
+}
+
+.email {
+  color: var(--color-primary-750);
+  text-decoration: none;
+  transition-timing-function: var(--transition-timing-function);
+  transition-duration: var(--transition-duration);
+  transition-property: var(--transition-property);
+
+  &:hover {
+    color: var(--color-primary-600);
+  }
 }

--- a/src/components/account/AccountHelpText.tsx
+++ b/src/components/account/AccountHelpText.tsx
@@ -50,5 +50,16 @@ export function AccountHelpText(): JSX.Element {
 
   const text = texts[role]
 
-  return <p className={css['text']}>{text}</p>
+  return (
+    <div className={css['lead']}>
+      <p className={css['text']}>
+        Hi, {currentUser.data?.displayName} (
+        <a className={css['email']} href={`mailto:${currentUser.data?.email}`}>
+          {currentUser.data?.email}
+        </a>
+        )!
+      </p>
+      <p className={css['text']}>{text}</p>
+    </div>
+  )
 }


### PR DESCRIPTION
closes #191

this adds a welcome message to the "my account" screen - main purpose is to display a user's email address, which is not visible anywhere else in the UI currently.