### PR TITLE
feat: allow extra help text for item property fields after vocabulary links

### DIFF
--- a/src/components/item-form/ConceptComboBox.tsx
+++ b/src/components/item-form/ConceptComboBox.tsx
@@ -3,7 +3,7 @@ import { Fragment, useMemo } from 'react'
 import { useForm } from 'react-final-form'
 
 import { ItemInfo } from '@/components/common/ItemInfo'
-import { Link } from '@/components/common/Link'
+import { SeeVocabularyLink } from '@/components/item-form/SeeVocabularyLink'
 import type { ItemFormFields } from '@/components/item-form/useItemFormFields'
 import type { PropertyType } from '@/data/sshoc/api/property'
 import { useConceptSearchInfinite } from '@/data/sshoc/hooks/vocabulary'
@@ -19,12 +19,10 @@ export interface ConceptComboBoxProps {
   setConceptSearchTerm: (searchTerm: string) => void
   field: ItemFormFields['fields']['properties']['fields']['concept']
   propertyTypeId: PropertyType['code']
-  allowedVocabularies: PropertyType['allowedVocabularies']
 }
 
 export function ConceptComboBox(props: ConceptComboBoxProps): JSX.Element {
-  const { conceptSearchTerm, field, propertyTypeId, allowedVocabularies, setConceptSearchTerm } =
-    props
+  const { conceptSearchTerm, field, propertyTypeId, setConceptSearchTerm } = props
 
   const { t } = useI18n<'authenticated' | 'common'>()
   const form = useForm()
@@ -74,26 +72,16 @@ export function ConceptComboBox(props: ConceptComboBoxProps): JSX.Element {
   const description = (
     <Fragment>
       <span>{field.description} </span>
-      {/* @ts-expect-error Assume all possible property types have translation. */}
-      <span>{t(['authenticated', 'properties', propertyTypeId, 'description'])} </span>
-      <small>
-        See{' '}
-        {allowedVocabularies.map((vocabulary, index) => {
-          const href = vocabulary.accessibleAt ?? vocabulary.namespace
-
-          if (href == null) return null
-
-          return (
-            <Fragment key={vocabulary.code}>
-              {index !== 0 ? ', ' : null}
-              <Link href={{ pathname: href }} target="_blank" rel="noreferrer">
-                {vocabulary.label}
-              </Link>
-            </Fragment>
-          )
+      <span>
+        {/* @ts-expect-error Assume all possible property types have translation. */}
+        {t(['authenticated', 'properties', propertyTypeId, 'description'], {
+          components: {
+            Link() {
+              return <SeeVocabularyLink type={propertyTypeId} />
+            },
+          },
         })}
-        .
-      </small>
+      </span>
     </Fragment>
   )
 

--- a/src/components/item-form/ItemProperty.tsx
+++ b/src/components/item-form/ItemProperty.tsx
@@ -77,7 +77,6 @@ export function ItemProperty(props: ItemPropertyProps): JSX.Element {
           setConceptSearchTerm={setConceptSearchTerm}
           field={fieldGroup.concept}
           propertyTypeId={selectedPropertyType.code}
-          allowedVocabularies={selectedPropertyType.allowedVocabularies}
         />
       ) : (
         <ValueTextField field={fieldGroup.value} propertyTypeId={selectedPropertyType.code} />

--- a/src/components/item-form/SeeVocabularyLink.tsx
+++ b/src/components/item-form/SeeVocabularyLink.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import { Fragment } from 'react'
+
+import { Link } from '@/components/common/Link'
+import type { StaticResult as PropertyTypes } from '@/components/item-form/property-types.static'
+import _propertyTypes from '@/components/item-form/property-types.static'
+
+const propertyTypes = _propertyTypes as unknown as PropertyTypes
+
+export function SeeVocabularyLink({ type }: { type: string }): JSX.Element | null {
+  return (
+    <Fragment>
+      {propertyTypes[type]!.allowedVocabularies.map((vocabulary, index) => {
+        const href = vocabulary.accessibleAt ?? vocabulary.namespace
+
+        if (href == null) return null
+
+        return (
+          <Fragment key={vocabulary.code}>
+            {index !== 0 ? ', ' : null}
+            <Link href={{ pathname: href }} target="_blank" rel="noreferrer">
+              {vocabulary.label}
+            </Link>
+          </Fragment>
+        )
+      })}
+    </Fragment>
+  )
+}

--- a/src/components/item-form/useItemFormFieldProperties.tsx
+++ b/src/components/item-form/useItemFormFieldProperties.tsx
@@ -1,3 +1,4 @@
+import { SeeVocabularyLink } from '@/components/item-form/SeeVocabularyLink'
 import { useI18n } from '@/lib/core/i18n/useI18n'
 
 /* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types */
@@ -11,7 +12,13 @@ export function useItemFormFieldProperties(prefix = '') {
     },
     activity: {
       name: `${prefix}activity`,
-      description: t(['authenticated', 'properties', 'activity', 'description']),
+      description: t(['authenticated', 'properties', 'activity', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="activity" />
+          },
+        },
+      }),
     },
     authentication: {
       name: `${prefix}authentication`,
@@ -23,11 +30,23 @@ export function useItemFormFieldProperties(prefix = '') {
     },
     discipline: {
       name: `${prefix}discipline`,
-      description: t(['authenticated', 'properties', 'discipline', 'description']),
+      description: t(['authenticated', 'properties', 'discipline', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="discipline" />
+          },
+        },
+      }),
     },
     'geographical-availability': {
       name: `${prefix}geographical-availability`,
-      description: t(['authenticated', 'properties', 'geographical-availability', 'description']),
+      description: t(['authenticated', 'properties', 'geographical-availability', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="geographical-availability" />
+          },
+        },
+      }),
     },
     'helpdesk-url': {
       name: `${prefix}helpdesk-url`,
@@ -37,29 +56,63 @@ export function useItemFormFieldProperties(prefix = '') {
       name: `${prefix}issue`,
       description: t(['authenticated', 'properties', 'issue', 'description']),
     },
+    inputformat: {
+      name: `${prefix}inputformat`,
+      description: t(['authenticated', 'properties', 'inputformat', 'description']),
+    },
     journal: {
       name: `${prefix}journal`,
       description: t(['authenticated', 'properties', 'journal', 'description']),
     },
     keyword: {
       name: `${prefix}keyword`,
-      description: t(['authenticated', 'properties', 'keyword', 'description']),
+      description: t(['authenticated', 'properties', 'keyword', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="keyword" />
+          },
+        },
+      }),
     },
     language: {
       name: `${prefix}language`,
-      description: t(['authenticated', 'properties', 'language', 'description']),
+      description: t(['authenticated', 'properties', 'language', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="language" />
+          },
+        },
+      }),
     },
     license: {
       name: `${prefix}license`,
-      description: t(['authenticated', 'properties', 'license', 'description']),
+      description: t(['authenticated', 'properties', 'license', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="license" />
+          },
+        },
+      }),
     },
     'life-cycle-status': {
       name: `${prefix}life-cycle-status`,
-      description: t(['authenticated', 'properties', 'life-cycle-status', 'description']),
+      description: t(['authenticated', 'properties', 'life-cycle-status', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="life-cycle-status" />
+          },
+        },
+      }),
     },
     'mode-of-use': {
       name: `${prefix}mode-of-use`,
-      description: t(['authenticated', 'properties', 'mode-of-use', 'description']),
+      description: t(['authenticated', 'properties', 'mode-of-use', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="mode-of-use" />
+          },
+        },
+      }),
     },
     // 'model-version': {
     //   name: `${prefix}model-version`,
@@ -67,7 +120,17 @@ export function useItemFormFieldProperties(prefix = '') {
     // },
     'object-format': {
       name: `${prefix}object-format`,
-      description: t(['authenticated', 'properties', 'object-format', 'description']),
+      description: t(['authenticated', 'properties', 'object-format', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="object-format" />
+          },
+        },
+      }),
+    },
+    outputformat: {
+      name: `${prefix}outputformat`,
+      description: t(['authenticated', 'properties', 'outputformat', 'description']),
     },
     pages: {
       name: `${prefix}pages`,
@@ -79,7 +142,13 @@ export function useItemFormFieldProperties(prefix = '') {
     },
     'publication-type': {
       name: `${prefix}publication-type`,
-      description: t(['authenticated', 'properties', 'publication-type', 'description']),
+      description: t(['authenticated', 'properties', 'publication-type', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="publication-type" />
+          },
+        },
+      }),
     },
     'publication-place': {
       name: `${prefix}publication-place`,
@@ -103,7 +172,13 @@ export function useItemFormFieldProperties(prefix = '') {
     // },
     'technical-readiness-level': {
       name: `${prefix}technical-readiness-level`,
-      description: t(['authenticated', 'properties', 'technical-readiness-level', 'description']),
+      description: t(['authenticated', 'properties', 'technical-readiness-level', 'description'], {
+        components: {
+          Link() {
+            return <SeeVocabularyLink type="technical-readiness-level" />
+          },
+        },
+      }),
     },
     'terms-of-use': {
       name: `${prefix}terms-of-use`,

--- a/src/dictionaries/authenticated/en.ts
+++ b/src/dictionaries/authenticated/en.ts
@@ -180,37 +180,62 @@ export const dictionary: Dictionary = {
   },
   properties: {
     'access-policy-url': { description: 'URL pointing to info about the access policy.' },
-    activity: { description: 'The activities you can do with the resource.' },
+    activity: {
+      description: 'The activities you can do with the resource. See <Link></Link>.',
+    },
     authentication: { description: 'Is authentication needed? Yes or no.' },
     conference: { description: 'Name of the conference where paper was given.' },
-    discipline: { description: 'Describes the discipline covered by resource.' },
+    discipline: {
+      description: 'Describes the discipline covered by resource. See <Link></Link>.',
+    },
     extent: { description: 'Describe the granularity of a resource.' },
-    'geographical-availability': { description: 'Locations where the Resource is offered.' },
+    'geographical-availability': {
+      description: 'Locations where the Resource is offered. See <Link></Link>.',
+    },
     'helpdesk-url': { description: 'URL to helpdesk for incidents & user requests.' },
-    'intended-audience': { description: 'Audience targeted by the resource.' },
+    inputformat: { description: 'See <Link></Link>.' },
+    'intended-audience': {
+      description: 'Audience targeted by the resource. See <Link></Link>.',
+    },
     issue: { description: 'A particular published issue of a journal.' },
     journal: { description: 'The journal the work was published in.' },
-    keyword: { description: 'Concept or term related to MP entry.' },
-    language: { description: 'Language(s) in which a resource is available.' },
-    license: { description: 'Select license pertaining to resource.' },
-    'life-cycle-status': { description: 'Status of the Resource life-cycle.' },
-    'mode-of-use': { description: 'Mode of use for the resource.' },
+    keyword: { description: 'Concept or term related to MP entry. See <Link></Link>.' },
+    language: {
+      description: 'Language(s) in which a resource is available. See <Link></Link>.',
+    },
+    license: {
+      description:
+        'Select license pertaining to resource. See <Link></Link>. If license is unknown, use the "Terms of use" property field to describe the usage terms.',
+    },
+    'life-cycle-status': {
+      description: 'Status of the Resource life-cycle. See <Link></Link>.',
+    },
+    'mode-of-use': { description: 'Mode of use for the resource. See <Link></Link>.' },
     // 'model-version': { description: '' },
-    'object-format': { description: 'File format of the linked resource.' },
+    'object-format': {
+      description: 'File format of the linked resource. See <Link></Link>.',
+    },
+    outputformat: { description: 'See <Link></Link>.' },
     pages: { description: 'Page #s of a resource, separate by commas.' },
     'privacy-policy-url': { description: 'Link to the privacy policy of resource.' },
     // 'processed-at': { description: '' },
     'publication-place': { description: 'The place of publication.' },
-    'publication-type': { description: 'The publication type, eg Book, article, etc.' },
+    'publication-type': {
+      description: 'The publication type, eg Book, article, etc. See <Link></Link>.',
+    },
     publisher: { description: 'Entity responsible for making the resource available.' },
-    'resource-category': { description: "Refine the resource's nature and function." },
+    'resource-category': {
+      description: "Refine the resource's nature and function. See <Link></Link>.",
+    },
     'see-also': { description: 'Links to non-MP materials that are relevant.' },
     'service-level-url': {
       description: 'Info about performance levels provider expected to deliver.',
     },
     // 'source-last-update': { description: '' },
-    standard: { description: 'Standard used by the resource.' },
-    'technical-readiness-level': { description: 'Technology Readiness Level of the Resource.' },
+    standard: { description: 'Standard used by the resource. See <Link></Link>.' },
+    'technical-readiness-level': {
+      description: 'Technology Readiness Level of the Resource. See <Link></Link>.',
+    },
     'terms-of-use': { description: 'If license unknown, fill in textbox.' },
     'terms-of-use-url': { description: 'Webpage describing terms of use.' },
     'tool-family': { description: 'Type of tool.' },

--- a/src/dictionaries/authenticated/index.ts
+++ b/src/dictionaries/authenticated/index.ts
@@ -130,6 +130,7 @@ export interface Dictionary {
     extent: Description
     'geographical-availability': Description
     'helpdesk-url': Description
+    inputformat: Description
     'intended-audience': Description
     issue: Description
     journal: Description
@@ -140,6 +141,7 @@ export interface Dictionary {
     'mode-of-use': Description
     // 'model-version': Description
     'object-format': Description
+    outputformat: Description
     pages: Description
     'privacy-policy-url': Description
     // 'processed-at': Description


### PR DESCRIPTION
this moves "See [allowed vocabulary]" help text links for item property fields into the i18n messages to allow adding additional helptext after the links.

adds extra help text for "license" field. closes #167