### PR TITLE
style: update breakpoints for last-updated section background

### DIFF
--- a/src/components/home/LastUpdatedItems.module.css
+++ b/src/components/home/LastUpdatedItems.module.css
@@ -5,7 +5,7 @@
 	align-content: start;
 	padding-block: var(--space-16);
 
-	@media (/* --screen-lg */ min-width: 64rem) {
+	@media (/* --screen-xl */ min-width: 80rem) {
 		padding-inline-start: var(--space-8);
 	}
 
@@ -18,7 +18,7 @@
 		background-color: var(--color-sidebar-background);
 		inset: 0;
 
-		@media (/* --screen-lg */ min-width: 64rem) {
+		@media (/* --screen-xl */ min-width: 80rem) {
 			grid-column: last-updated-items / -1;
 		}
 	}


### PR DESCRIPTION
this updates the media query for the background fill of the "last-updated" home page section (layout media query was changed in https://github.com/SSHOC/sshoc-marketplace-frontend/commit/61f126e887a6d6745debd99795461c3b38c7697a).