### PR TITLE
refactor: convert next.config to typescript

### DIFF
--- a/config/docs.config.mjs
+++ b/config/docs.config.mjs
@@ -1,2 +1,0 @@
-/** @type {import('shiki').Theme} */
-export const syntaxHighlightingTheme = "material-ocean";

--- a/config/docs.config.ts
+++ b/config/docs.config.ts
@@ -1,0 +1,3 @@
+import type { Theme } from "shiki";
+
+export const syntaxHighlightingTheme: Theme = "material-ocean";

--- a/config/i18n.config.mjs
+++ b/config/i18n.config.mjs
@@ -1,8 +1,0 @@
-/** @typedef {Mutable<typeof supportedLocales>} Locales */
-/** @typedef {Locales[number]} Locale */
-
-const supportedLocales = /** @type {const} */ (["en"]);
-
-export const defaultLocale = /** @type {Locale} */ ("en");
-
-export const locales = /** @type {Locales} */ (supportedLocales);

--- a/config/i18n.config.ts
+++ b/config/i18n.config.ts
@@ -1,0 +1,6 @@
+export const locales = ["en"] as const;
+
+export type Locale = (typeof locales)[number];
+export type Locales = Array<Locale>;
+
+export const defaultLocale = "en";

--- a/config/metadata.config.ts
+++ b/config/metadata.config.ts
@@ -1,5 +1,5 @@
 import { createSiteUrl } from "@/lib/utils";
-import type { Locale } from "~/config/i18n.config.mjs";
+import type { Locale } from "~/config/i18n.config";
 
 export interface SiteMetadata {
 	locale: Locale;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 /* global process */
 
 import { log } from "@acdh-oeaw/lib";
+import type { Options as MdxOptions } from "@mdx-js/loader";
 import createBundleAnalyzer from "@next/bundle-analyzer";
 import createSvgPlugin from "@stefanprobst/next-svg";
 import withToc from "@stefanprobst/rehype-extract-toc";
@@ -14,28 +15,25 @@ import withNoReferrerLinks from "@stefanprobst/rehype-noreferrer-links";
 import withSyntaxHighlighting from "@stefanprobst/rehype-shiki";
 import withParsedFrontmatter from "@stefanprobst/remark-extract-yaml-frontmatter";
 import withParsedFrontmatterExport from "@stefanprobst/remark-extract-yaml-frontmatter/mdx";
+import type { Options as MdxPageOptions } from "@stefanprobst/remark-mdx-page";
 import withPage from "@stefanprobst/remark-mdx-page";
 import withSmartQuotes from "@stefanprobst/remark-smart-quotes";
+import type { Element as HastElement } from "hast";
 import { headingRank } from "hast-util-heading-rank";
 import { h } from "hastscript";
+import type { NextConfig as Config } from "next";
 import * as path from "path";
 import withHeadingIds from "rehype-slug";
 import withFrontmatter from "remark-frontmatter";
 import withGfm from "remark-gfm";
 import { getHighlighter } from "shiki";
 
-import { syntaxHighlightingTheme } from "./config/docs.config.mjs";
-import { defaultLocale, locales } from "./config/i18n.config.mjs";
+import { syntaxHighlightingTheme } from "~/config/docs.config";
+import { defaultLocale, locales } from "~/config/i18n.config";
 
-/** @typedef {import('~/config/i18n.config.mjs').Locale} Locale */
-/** @typedef {import('next').NextConfig & {i18n?: {locales: Array<Locale>; defaultLocale: Locale}}} NextConfig */
-/** @typedef {import('webpack').Configuration} WebpackConfig */
-/** @typedef {import('@mdx-js/loader').Options} MdxOptions */
-/** @typedef {import('@stefanprobst/remark-mdx-page').Options} MdxPageOptions */
-/** @typedef {import('hast').Element} HastElement */
+type NextConfig = Config;
 
-/** @type {NextConfig} */
-const config = {
+const config: NextConfig = {
 	eslint: {
 		dirs: ["."],
 		ignoreDuringBuilds: true,
@@ -114,7 +112,7 @@ const config = {
 	typescript: {
 		ignoreBuildErrors: true,
 	},
-	webpack(/** @type {WebpackConfig} */ config, context) {
+	webpack(config, context) {
 		/**
 		 * @see https://github.com/vercel/next.js/discussions/30870
 		 */
@@ -135,8 +133,7 @@ const config = {
 			},
 		});
 
-		/** @type {(heading: HastElement, id: string) => Array<HastElement>} */
-		function createPermalink(headingElement, id) {
+		function createPermalink(headingElement: HastElement, id: string): Array<HastElement> {
 			const permaLinkId = ["permalink", id].join("-");
 			const ariaLabelledBy = [permaLinkId, id].join(" ");
 
@@ -159,7 +156,6 @@ const config = {
 				context.defaultLoaders.babel,
 				{
 					loader: "@mdx-js/loader",
-					/** @type {MdxOptions} */
 					options: {
 						jsx: true,
 						remarkPlugins: [
@@ -178,7 +174,7 @@ const config = {
 							withHeadingIds,
 							[withHeadingFragmentLinks, { generate: createPermalink }],
 						],
-					},
+					} satisfies MdxOptions,
 				},
 			],
 		});
@@ -202,7 +198,7 @@ const config = {
 				context.defaultLoaders.babel,
 				{
 					loader: "@mdx-js/loader",
-					/** @type {MdxOptions} */
+
 					options: {
 						jsx: true,
 						remarkPlugins: [
@@ -237,18 +233,17 @@ const config = {
 						recmaPlugins: [
 							[
 								withPage,
-								/** @type {MdxPageOptions} */
-								({
+								{
 									template: aboutPageTemplate,
 									imports: [
 										'import { Image } from "@/components/common/Image"',
 										'import { Link } from "@/components/common/Link"',
 									],
 									props: "{ components: { Image, Link }, metadata, tableOfContents }",
-								}),
+								} satisfies MdxPageOptions,
 							],
 						],
-					},
+					} satisfies MdxOptions,
 				},
 			],
 		});
@@ -272,7 +267,6 @@ const config = {
 				context.defaultLoaders.babel,
 				{
 					loader: "@mdx-js/loader",
-					/** @type {MdxOptions} */
 					options: {
 						jsx: true,
 						remarkPlugins: [
@@ -307,18 +301,17 @@ const config = {
 						recmaPlugins: [
 							[
 								withPage,
-								/** @type {MdxPageOptions} */
-								({
+								{
 									template: contributePageTemplate,
 									imports: [
 										'import { Image } from "@/components/common/Image"',
 										'import { Link } from "@/components/common/Link"',
 									],
 									props: "{ components: { Image, Link }, metadata, tableOfContents }",
-								}),
+								} satisfies MdxPageOptions,
 							],
 						],
-					},
+					} satisfies MdxOptions,
 				},
 			],
 		});
@@ -327,8 +320,7 @@ const config = {
 	},
 };
 
-/** @type {Array<(config: NextConfig) => NextConfig>} */
-const plugins = [
+const plugins: Array<(config: NextConfig) => NextConfig> = [
 	createSvgPlugin(),
 	createBundleAnalyzer({ enabled: process.env["BUNDLE_ANALYZER"] === "enabled" }),
 ];

--- a/src/lib/cms/components/create-processor.ts
+++ b/src/lib/cms/components/create-processor.ts
@@ -8,7 +8,7 @@ import toHast from "remark-rehype";
 import { getHighlighter } from "shiki";
 import { unified } from "unified";
 
-import { syntaxHighlightingTheme } from "~/config/docs.config.mjs";
+import { syntaxHighlightingTheme } from "~/config/docs.config";
 
 const processor = unified()
 	.use(fromMarkdown)

--- a/src/lib/cms/previews/create-mock-router.ts
+++ b/src/lib/cms/previews/create-mock-router.ts
@@ -1,7 +1,7 @@
 import type { NextRouter } from "next/router";
 
 import { noop } from "@/lib/utils";
-import { defaultLocale, locales } from "~/config/i18n.config.mjs";
+import { defaultLocale, locales } from "~/config/i18n.config";
 
 export const mockRouter: NextRouter = {
 	basePath: "/",

--- a/src/lib/core/i18n/getLocale.ts
+++ b/src/lib/core/i18n/getLocale.ts
@@ -1,7 +1,7 @@
 import type { GetServerSidePropsContext, GetStaticPropsContext } from "next";
 import type { NextRouter } from "next/router";
 
-import type { Locale } from "~/config/i18n.config.mjs";
+import type { Locale } from "~/config/i18n.config";
 
 export function getLocale(
 	context: GetServerSidePropsContext | GetStaticPropsContext | NextRouter,

--- a/src/lib/core/i18n/getLocales.ts
+++ b/src/lib/core/i18n/getLocales.ts
@@ -1,6 +1,6 @@
 import type { GetStaticPathsContext } from "next";
 
-import type { Locales } from "~/config/i18n.config.mjs";
+import type { Locales } from "~/config/i18n.config";
 
 export function getLocales(context: GetStaticPathsContext): Locales {
 	return context.locales as Locales;

--- a/src/lib/core/i18n/load.ts
+++ b/src/lib/core/i18n/load.ts
@@ -1,5 +1,5 @@
 import type { Dictionary } from "@/dictionaries";
-import type { Locale } from "~/config/i18n.config.mjs";
+import type { Locale } from "~/config/i18n.config";
 
 export async function load<K extends keyof Dictionary>(
 	locale: Locale,

--- a/src/lib/core/i18n/useI18n.ts
+++ b/src/lib/core/i18n/useI18n.ts
@@ -2,7 +2,7 @@ import type { I18nContextValue } from "@stefanprobst/next-i18n";
 import { useI18n as _useI18n } from "@stefanprobst/next-i18n";
 
 import type { Dictionary } from "@/dictionaries";
-import type { Locale } from "~/config/i18n.config.mjs";
+import type { Locale } from "~/config/i18n.config";
 
 export function useI18n<K extends keyof Dictionary = never>(): I18nContextValue<
 	Pick<Dictionary, K>,

--- a/src/lib/core/i18n/useLocale.ts
+++ b/src/lib/core/i18n/useLocale.ts
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 
-import type { Locale, Locales } from "~/config/i18n.config.mjs";
+import type { Locale, Locales } from "~/config/i18n.config";
 
 export interface UseLocaleResult {
 	locale: Locale;

--- a/src/lib/core/metadata/useAlternateLocaleUrls.ts
+++ b/src/lib/core/metadata/useAlternateLocaleUrls.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useLocale } from "@/lib/core/i18n/useLocale";
 import { usePathname } from "@/lib/core/navigation/usePathname";
 import { createSiteUrl } from "@/lib/utils";
-import type { Locale } from "~/config/i18n.config.mjs";
+import type { Locale } from "~/config/i18n.config";
 
 export type UseAlternateLocaleUrlsResult = Array<{ hrefLang: Locale; href: string }>;
 

--- a/src/lib/core/ui/Link/Link.tsx
+++ b/src/lib/core/ui/Link/Link.tsx
@@ -8,7 +8,7 @@ import { forwardRef, useRef } from "react";
 import useComposedRef from "use-composed-ref";
 
 import css from "@/lib/core/ui/Link/Link.module.css";
-import type { Locale } from "~/config/i18n.config.mjs";
+import type { Locale } from "~/config/i18n.config";
 
 export interface LinkStyleProps {
 	"--link-color"?: CSSProperties["color"];

--- a/src/lib/core/ui/Link/LinkButton.tsx
+++ b/src/lib/core/ui/Link/LinkButton.tsx
@@ -11,7 +11,7 @@ import useComposedRef from "use-composed-ref";
 import type { ButtonProps } from "@/lib/core/ui/Button/Button";
 import css from "@/lib/core/ui/Button/Button.module.css";
 import linkStyles from "@/lib/core/ui/Link/Link.module.css";
-import type { Locale } from "~/config/i18n.config.mjs";
+import type { Locale } from "~/config/i18n.config";
 
 export interface LinkButtonProps
 	extends AriaLinkProps,

--- a/src/lib/utils/create-favicon-link.ts
+++ b/src/lib/utils/create-favicon-link.ts
@@ -1,6 +1,5 @@
 import { createSiteUrl } from "@/lib/utils";
-import type { Locale } from "~/config/i18n.config.mjs";
-import { defaultLocale } from "~/config/i18n.config.mjs";
+import { defaultLocale, type Locale } from "~/config/i18n.config";
 
 export function createFaviconLink(locale: Locale, fileName: string): URL {
 	return createSiteUrl({

--- a/src/lib/utils/create-site-url.ts
+++ b/src/lib/utils/create-site-url.ts
@@ -1,7 +1,7 @@
 import type { UrlInit } from "@stefanprobst/request";
 import { createUrl } from "@stefanprobst/request";
 
-import type { Locale } from "~/config/i18n.config.mjs";
+import type { Locale } from "~/config/i18n.config";
 import { baseUrl } from "~/config/site.config";
 
 export function createSiteUrl(


### PR DESCRIPTION
this converts next.config.mjs to next.config.ts (supported in next.js v15) - also converts all other config files.