### PR TITLE
build: copy next.config.ts in docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM base AS build
 
 RUN yarn install --frozen-lockfile --ignore-scripts --silent --prefer-offline
 
-COPY --chown=node:node tsconfig.json app.d.ts next-env.d.ts next.config.mjs ./
+COPY --chown=node:node tsconfig.json app.d.ts next-env.d.ts next.config.ts ./
 COPY --chown=node:node scripts ./scripts
 COPY --chown=node:node config ./config
 COPY --chown=node:node public ./public
@@ -53,7 +53,7 @@ WORKDIR /app
 
 USER node
 
-COPY --from=build --chown=node:node /app/next.config.mjs ./
+COPY --from=build --chown=node:node /app/next.config.ts ./
 COPY --from=build --chown=node:node /app/public ./public
 COPY --from=build --chown=node:node /app/.next/standalone ./
 COPY --from=build --chown=node:node /app/.next/static ./.next/static


### PR DESCRIPTION
follow-up to #248.this copies the typescript next config to the docker build context.