### PR TITLE
build: patch packages for incorrect esm in next

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 USER node
 
 COPY --chown=node:node package.json yarn.lock ./
+COPY --chown=node:node ./patches ./patches
 
 # cannot use `--ignore-scripts` for `sharp` to compile
 RUN yarn install --frozen-lockfile --silent --production && yarn cache clean

--- a/patches/@stefanprobst+next-svg+4.2.1.patch
+++ b/patches/@stefanprobst+next-svg+4.2.1.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@stefanprobst/next-svg/package.json b/node_modules/@stefanprobst/next-svg/package.json
+index 537ec18..58663a0 100644
+--- a/node_modules/@stefanprobst/next-svg/package.json
++++ b/node_modules/@stefanprobst/next-svg/package.json
+@@ -8,7 +8,8 @@
+   "exports": {
+     ".": {
+       "types": "./src/index.d.ts",
+-      "import": "./src/index.js"
++      "import": "./src/index.js",
++      "default": "./src/index.js"
+     },
+     "./svg-symbol-loader": "./src/svg-symbol-loader.cjs",
+     "./svg-inline-loader": "./src/svg-inline-loader.cjs",

--- a/patches/@stefanprobst+rehype-extract-toc+2.1.3.patch
+++ b/patches/@stefanprobst+rehype-extract-toc+2.1.3.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@stefanprobst/rehype-extract-toc/package.json b/node_modules/@stefanprobst/rehype-extract-toc/package.json
+index 693d6ce..e6c8b40 100644
+--- a/node_modules/@stefanprobst/rehype-extract-toc/package.json
++++ b/node_modules/@stefanprobst/rehype-extract-toc/package.json
+@@ -10,11 +10,13 @@
+   "exports": {
+     ".": {
+       "types": "./src/index.d.ts",
+-      "import": "./src/index.js"
++      "import": "./src/index.js",
++      "default": "./src/index.js"
+     },
+     "./mdx": {
+       "types": "./src/mdx.d.ts",
+-      "import": "./src/mdx.js"
++      "import": "./src/mdx.js",
++      "default": "./src/mdx.js"
+     }
+   },
+   "files": [

--- a/patches/@stefanprobst+rehype-image-captions+1.1.0.patch
+++ b/patches/@stefanprobst+rehype-image-captions+1.1.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@stefanprobst/rehype-image-captions/package.json b/node_modules/@stefanprobst/rehype-image-captions/package.json
+index f9e4077..acdfe04 100644
+--- a/node_modules/@stefanprobst/rehype-image-captions/package.json
++++ b/node_modules/@stefanprobst/rehype-image-captions/package.json
+@@ -7,7 +7,8 @@
+   "types": "./src/index.d.ts",
+   "exports": {
+     "types": "./src/index.d.ts",
+-    "import": "./src/index.js"
++    "import": "./src/index.js",
++    "default": "./src/index.js"
+   },
+   "files": [
+     "src"

--- a/patches/@stefanprobst+rehype-next-image+1.0.0.patch
+++ b/patches/@stefanprobst+rehype-next-image+1.0.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@stefanprobst/rehype-next-image/package.json b/node_modules/@stefanprobst/rehype-next-image/package.json
+index b72ea19..45a5798 100644
+--- a/node_modules/@stefanprobst/rehype-next-image/package.json
++++ b/node_modules/@stefanprobst/rehype-next-image/package.json
+@@ -7,7 +7,8 @@
+   "license": "MIT",
+   "exports": {
+     "types": "./src/index.d.ts",
+-    "import": "./src/index.js"
++    "import": "./src/index.js",
++    "default": "./src/index.js"
+   },
+   "files": [
+     "src"

--- a/patches/@stefanprobst+rehype-next-links+2.0.2.patch
+++ b/patches/@stefanprobst+rehype-next-links+2.0.2.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@stefanprobst/rehype-next-links/package.json b/node_modules/@stefanprobst/rehype-next-links/package.json
+index ca3bd88..b35e636 100644
+--- a/node_modules/@stefanprobst/rehype-next-links/package.json
++++ b/node_modules/@stefanprobst/rehype-next-links/package.json
+@@ -7,7 +7,8 @@
+   "types": "./src/index.d.ts",
+   "exports": {
+     "types": "./src/index.d.ts",
+-    "import": "./src/index.js"
++    "import": "./src/index.js",
++    "default": "./src/index.js"
+   },
+   "files": [
+     "src"

--- a/patches/@stefanprobst+remark-extract-yaml-frontmatter+2.2.3.patch
+++ b/patches/@stefanprobst+remark-extract-yaml-frontmatter+2.2.3.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@stefanprobst/remark-extract-yaml-frontmatter/package.json b/node_modules/@stefanprobst/remark-extract-yaml-frontmatter/package.json
+index c5f48b6..681fdf8 100644
+--- a/node_modules/@stefanprobst/remark-extract-yaml-frontmatter/package.json
++++ b/node_modules/@stefanprobst/remark-extract-yaml-frontmatter/package.json
+@@ -10,11 +10,13 @@
+   "exports": {
+     ".": {
+       "types": "./src/index.d.ts",
+-      "import": "./src/index.js"
++      "import": "./src/index.js",
++      "default": "./src/index.js"
+     },
+     "./mdx": {
+       "types": "./src/mdx.d.ts",
+-      "import": "./src/mdx.js"
++      "import": "./src/mdx.js",
++      "default": "./src/mdx.js"
+     }
+   },
+   "files": [

--- a/patches/@stefanprobst+remark-mdx-page+3.0.1.patch
+++ b/patches/@stefanprobst+remark-mdx-page+3.0.1.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@stefanprobst/remark-mdx-page/package.json b/node_modules/@stefanprobst/remark-mdx-page/package.json
+index 5636e71..a8e2131 100644
+--- a/node_modules/@stefanprobst/remark-mdx-page/package.json
++++ b/node_modules/@stefanprobst/remark-mdx-page/package.json
+@@ -8,7 +8,8 @@
+   "license": "MIT",
+   "exports": {
+     "types": "./src/index.d.ts",
+-    "import": "./src/index.js"
++    "import": "./src/index.js",
++    "default": "./src/index.js"
+   },
+   "files": [
+     "src"


### PR DESCRIPTION
this patches a couple of packages to add a `default` export condition to `package.json`. this should not be necessary, as these packages are esm-only and have a `import` export condition, but it's a known upstream issue with next.js bundling.