### PR TITLE
chore: don't open readme on vscode startup [skip ci]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,6 @@
 	"tailwindCSS.validate": false,
 	"typescript.preferences.importModuleSpecifier": "non-relative",
 	"typescript.tsdk": "node_modules/typescript/lib",
-	"workbench.startupEditor": "readme",
 	"workbench.tree.indent": 16,
 	"[markdown]": {
 		"editor.wordWrap": "on"


### PR DESCRIPTION
this removes the annoying vscode settings to open the readme file on startup.