### PR TITLE
feat: validate environment variables

### DIFF
--- a/config/analytics.config.ts
+++ b/config/analytics.config.ts
@@ -1,3 +1,5 @@
-export const baseUrl = process.env.NEXT_PUBLIC_MATOMO_BASE_URL;
+import { env } from "@/config/env.config";
 
-export const appId = process.env.NEXT_PUBLIC_MATOMO_ID;
+export const baseUrl = env.NEXT_PUBLIC_MATOMO_BASE_URL;
+
+export const appId = env.NEXT_PUBLIC_MATOMO_ID;

--- a/config/email.config.ts
+++ b/config/email.config.ts
@@ -1,6 +1,7 @@
-export const smtpServer = process.env.SMTP_SERVER;
+import { env } from "@/config/env.config";
 
-export const smtpPort =
-	process.env.SMTP_PORT != null ? parseInt(process.env.SMTP_PORT, 10) : undefined;
+export const smtpServer = env.SMTP_SERVER;
 
-export const sshocContactEmailAddress = process.env.SSHOC_CONTACT_EMAIL_ADDRESS;
+export const smtpPort = env.SMTP_PORT;
+
+export const sshocContactEmailAddress = env.SSHOC_CONTACT_EMAIL_ADDRESS;

--- a/config/env.config.ts
+++ b/config/env.config.ts
@@ -36,18 +36,18 @@ export const env = createEnv({
 			NEXT_PUBLIC_BOTS: v.optional(v.picklist(["disabled", "enabled"]), "disabled"),
 			NEXT_PUBLIC_GITHUB_REPOSITORY: v.optional(v.pipe(v.string(), v.nonEmpty())),
 			NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: v.optional(v.pipe(v.string(), v.nonEmpty())),
-			NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL: v.pipe(v.string(), v.url()),
+			// NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL: v.pipe(v.string(), v.url()),
 			NEXT_PUBLIC_MATOMO_BASE_URL: v.optional(v.pipe(v.string(), v.url())),
 			NEXT_PUBLIC_MATOMO_ID: v.optional(
 				v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1)),
 			),
-			NEXT_PUBLIC_REDMINE_ID: v.pipe(
-				v.string(),
-				v.transform(Number),
-				v.number(),
-				v.integer(),
-				v.minValue(1),
-			),
+			// NEXT_PUBLIC_REDMINE_ID: v.pipe(
+			// 	v.string(),
+			// 	v.transform(Number),
+			// 	v.number(),
+			// 	v.integer(),
+			// 	v.minValue(1),
+			// ),
 		});
 
 		return v.parse(Schema, input);
@@ -62,10 +62,10 @@ export const env = createEnv({
 		NEXT_PUBLIC_BOTS: process.env.NEXT_PUBLIC_BOTS,
 		NEXT_PUBLIC_GITHUB_REPOSITORY: process.env.NEXT_PUBLIC_GITHUB_REPOSITORY,
 		NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
-		NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL: process.env.NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL,
+		// NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL: process.env.NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL,
 		NEXT_PUBLIC_MATOMO_BASE_URL: process.env.NEXT_PUBLIC_MATOMO_BASE_URL,
 		NEXT_PUBLIC_MATOMO_ID: process.env.NEXT_PUBLIC_MATOMO_ID,
-		NEXT_PUBLIC_REDMINE_ID: process.env.NEXT_PUBLIC_REDMINE_ID,
+		// NEXT_PUBLIC_REDMINE_ID: process.env.NEXT_PUBLIC_REDMINE_ID,
 		NEXT_RUNTIME: process.env.NEXT_RUNTIME,
 		NODE_ENV: process.env.NODE_ENV,
 		REVALIDATION_TOKEN: process.env.REVALIDATION_TOKEN,

--- a/config/env.config.ts
+++ b/config/env.config.ts
@@ -1,0 +1,92 @@
+import { log } from "@acdh-oeaw/lib";
+import { createEnv } from "@acdh-oeaw/validate-env/next";
+import * as v from "valibot";
+
+export const env = createEnv({
+	system(input) {
+		const Schema = v.object({
+			NODE_ENV: v.optional(v.picklist(["development", "production", "test"]), "production"),
+		});
+
+		return v.parse(Schema, input);
+	},
+	private(input) {
+		const Schema = v.object({
+			BUILD_MODE: v.optional(v.picklist(["export", "standalone"])),
+			BUNDLE_ANALYZER: v.optional(v.picklist(["disabled", "enabled"]), "disabled"),
+			CI: v.optional(v.pipe(v.unknown(), v.transform(Boolean), v.boolean())),
+			GITHUB_TOKEN: v.optional(v.pipe(v.string(), v.nonEmpty())),
+			NEXT_RUNTIME: v.optional(v.picklist(["edge", "nodejs"])),
+			REVALIDATION_TOKEN: v.pipe(v.string(), v.nonEmpty()),
+			SMTP_PORT: v.optional(
+				v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1)),
+			),
+			SMTP_SERVER: v.optional(v.pipe(v.string(), v.nonEmpty())),
+			SSHOC_CONTACT_EMAIL_ADDRESS: v.optional(v.pipe(v.string(), v.email())),
+		});
+
+		return v.parse(Schema, input);
+	},
+	public(input) {
+		const Schema = v.object({
+			NEXT_PUBLIC_API_BASE_URL: v.pipe(v.string(), v.url()),
+			NEXT_PUBLIC_APP_BASE_URL: v.pipe(v.string(), v.url()),
+			NEXT_PUBLIC_BOTS: v.optional(v.picklist(["disabled", "enabled"]), "disabled"),
+			NEXT_PUBLIC_GITHUB_REPOSITORY: v.optional(v.pipe(v.string(), v.nonEmpty())),
+			NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: v.optional(v.pipe(v.string(), v.nonEmpty())),
+			NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL: v.pipe(v.string(), v.url()),
+			NEXT_PUBLIC_MATOMO_BASE_URL: v.optional(v.pipe(v.string(), v.url())),
+			NEXT_PUBLIC_MATOMO_ID: v.optional(
+				v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1)),
+			),
+			NEXT_PUBLIC_REDMINE_ID: v.pipe(
+				v.string(),
+				v.transform(Number),
+				v.number(),
+				v.integer(),
+				v.minValue(1),
+			),
+		});
+
+		return v.parse(Schema, input);
+	},
+	environment: {
+		BUILD_MODE: process.env.BUILD_MODE,
+		BUNDLE_ANALYZER: process.env.BUNDLE_ANALYZER,
+		CI: process.env.CI,
+		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+		NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+		NEXT_PUBLIC_APP_BASE_URL: process.env.NEXT_PUBLIC_APP_BASE_URL,
+		NEXT_PUBLIC_BOTS: process.env.NEXT_PUBLIC_BOTS,
+		NEXT_PUBLIC_GITHUB_REPOSITORY: process.env.NEXT_PUBLIC_GITHUB_REPOSITORY,
+		NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+		NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL: process.env.NEXT_PUBLIC_IMPRINT_SERVICE_BASE_URL,
+		NEXT_PUBLIC_MATOMO_BASE_URL: process.env.NEXT_PUBLIC_MATOMO_BASE_URL,
+		NEXT_PUBLIC_MATOMO_ID: process.env.NEXT_PUBLIC_MATOMO_ID,
+		NEXT_PUBLIC_REDMINE_ID: process.env.NEXT_PUBLIC_REDMINE_ID,
+		NEXT_RUNTIME: process.env.NEXT_RUNTIME,
+		NODE_ENV: process.env.NODE_ENV,
+		REVALIDATION_TOKEN: process.env.REVALIDATION_TOKEN,
+		SMTP_PORT: process.env.SMTP_PORT,
+		SMTP_SERVER: process.env.SMTP_SERVER,
+		SSHOC_CONTACT_EMAIL_ADDRESS: process.env.SSHOC_CONTACT_EMAIL_ADDRESS,
+	},
+	validation: v.parse(
+		v.optional(v.picklist(["disabled", "enabled", "public"]), "enabled"),
+		process.env.ENV_VALIDATION,
+	),
+	onError(error) {
+		if (v.isValiError(error)) {
+			const message = "Invalid environment variables";
+
+			log.error(`${message}:`, v.flatten(error.issues).nested);
+
+			const validationError = new Error(message);
+			delete validationError.stack;
+
+			throw validationError;
+		}
+
+		throw error;
+	},
+});

--- a/config/env.config.ts
+++ b/config/env.config.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+
 import { log } from "@acdh-oeaw/lib";
 import { createEnv } from "@acdh-oeaw/validate-env/next";
 import * as v from "valibot";

--- a/config/site.config.ts
+++ b/config/site.config.ts
@@ -1,4 +1,6 @@
-export const baseUrl = process.env.NEXT_PUBLIC_APP_BASE_URL ?? "http://localhost:3000";
+import { env } from "@/config/env.config";
+
+export const baseUrl = env.NEXT_PUBLIC_APP_BASE_URL;
 
 export const webManifest = "site.webmanifest";
 
@@ -6,4 +8,4 @@ export const openGraphImageName = "open-graph.webp";
 
 export const toastAutoCloseDelay = 7500;
 
-export const googleSiteId = process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION;
+export const googleSiteId = env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION;

--- a/config/sshoc.config.ts
+++ b/config/sshoc.config.ts
@@ -1,3 +1,4 @@
+import { env } from "@/config/env.config";
 import type { ItemDraftSortOrder, ItemSortOrder, ItemStatus } from "@/data/sshoc/api/item";
 import { itemSortOrders, itemStatus } from "@/data/sshoc/api/item";
 import type { SourceSortOrder } from "@/data/sshoc/api/source";
@@ -70,4 +71,4 @@ export const relatedItemsPage = 10;
 
 export const debounceDelay = 150; /** ms */
 
-export const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+export const baseUrl = env.NEXT_PUBLIC_API_BASE_URL;

--- a/data/git/get-last-updated-timestamp.ts
+++ b/data/git/get-last-updated-timestamp.ts
@@ -1,7 +1,9 @@
 import { log } from "@acdh-oeaw/lib";
 import { createUrl, request } from "@stefanprobst/request";
 
-const repo = process.env.NEXT_PUBLIC_GITHUB_REPOSITORY;
+import { env } from "@/config/env.config";
+
+const repo = env.NEXT_PUBLIC_GITHUB_REPOSITORY;
 
 async function getCommits(filePath: string) {
 	const url = createUrl({
@@ -10,7 +12,7 @@ async function getCommits(filePath: string) {
 		searchParams: { path: filePath },
 	});
 
-	const token = process.env.GITHUB_TOKEN;
+	const token = env.GITHUB_TOKEN;
 	const headers = token != null ? { authorization: `Bearer ${token}` } : undefined;
 
 	if (token == null) {
@@ -21,7 +23,7 @@ async function getCommits(filePath: string) {
 }
 
 export async function getLastUpdatedTimestamp(filePath: string): Promise<Date> {
-	if (process.env.NODE_ENV !== "production") {
+	if (env.NODE_ENV !== "production") {
 		return new Date();
 	}
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,6 +19,13 @@ export default config(
 	},
 	{
 		rules: {
+			"no-restricted-syntax": [
+				"error",
+				{
+					selector: 'MemberExpression[computed!=true][object.name="process"][property.name="env"]',
+					message: "Please use `@/config/env.config` instead.",
+				},
+			],
 			"prefer-template": "off",
 			"@typescript-eslint/consistent-type-definitions": "off",
 			"@typescript-eslint/dot-notation": "off",

--- a/lib/core/auth/AuthProvider.tsx
+++ b/lib/core/auth/AuthProvider.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { createContext, useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation } from "react-query";
 
+import { env } from "@/config/env.config";
 import type { OAuthRegistrationInput, SignInInput, SignUpResponse } from "@/data/sshoc/api/auth";
 import {
 	authorizeWithEosc,
@@ -125,7 +126,7 @@ export interface AuthService {
 }
 
 export const AuthContext = createContext<AuthService | null>(null);
-if (process.env.NODE_ENV !== "production") {
+if (env.NODE_ENV !== "production") {
 	AuthContext.displayName = "AuthContext";
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,9 @@
-/* global process */
-
 import { log } from "@acdh-oeaw/lib";
 import createBundleAnalyzer from "@next/bundle-analyzer";
 import createSvgPlugin from "@stefanprobst/next-svg";
 import type { NextConfig as Config } from "next";
 
+import { env } from "@/config/env.config";
 import { defaultLocale, locales } from "@/config/i18n.config";
 
 type NextConfig = Config;
@@ -27,7 +26,7 @@ const config: NextConfig = {
 			},
 		];
 
-		if (process.env.NEXT_PUBLIC_BOTS !== "enabled") {
+		if (env.NEXT_PUBLIC_BOTS !== "enabled") {
 			headers.push({
 				source: "/:path*",
 				headers: [
@@ -48,10 +47,7 @@ const config: NextConfig = {
 		defaultLocale,
 	},
 	images: {
-		remotePatterns:
-			process.env.NEXT_PUBLIC_API_BASE_URL != null
-				? [new URL(process.env.NEXT_PUBLIC_API_BASE_URL)]
-				: undefined,
+		remotePatterns: [new URL(env.NEXT_PUBLIC_API_BASE_URL)],
 	},
 	output: "standalone",
 	poweredByHeader: false,
@@ -103,7 +99,7 @@ const config: NextConfig = {
 
 const plugins: Array<(config: NextConfig) => NextConfig> = [
 	createSvgPlugin(),
-	createBundleAnalyzer({ enabled: process.env.BUNDLE_ANALYZER === "enabled" }),
+	createBundleAnalyzer({ enabled: env.BUNDLE_ANALYZER === "enabled" }),
 ];
 
 export default plugins.reduce((config, plugin) => {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 	},
 	"dependencies": {
 		"@acdh-oeaw/lib": "^0.3.2",
+		"@acdh-oeaw/validate-env": "^0.0.3",
 		"@mdx-js/mdx": "^3.1.0",
 		"@next/bundle-analyzer": "^15.3.1",
 		"@react-aria/accordion": "^3.0.0-alpha.37",
@@ -114,6 +115,7 @@
 		"to-vfile": "^8.0.0",
 		"unified": "^11.0.5",
 		"use-composed-ref": "^1.4.0",
+		"valibot": "^1.0.0",
 		"vfile": "^6.0.3",
 		"vfile-matter": "^5.0.1",
 		"zod": "^3.24.3"

--- a/pages/api/revalidate.ts
+++ b/pages/api/revalidate.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { env } from "@/config/env.config";
 import { baseUrl } from "@/config/site.config";
 import { isNonEmptyString } from "@/lib/utils";
 
@@ -12,7 +13,7 @@ export default async function handler(
 		return;
 	}
 
-	const secret = process.env.REVALIDATION_TOKEN;
+	const secret = env.REVALIDATION_TOKEN;
 
 	if (!isNonEmptyString(secret)) {
 		response.status(500).end();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@acdh-oeaw/lib':
         specifier: ^0.3.2
         version: 0.3.2
+      '@acdh-oeaw/validate-env':
+        specifier: ^0.0.3
+        version: 0.0.3
       '@mdx-js/mdx':
         specifier: ^3.1.0
         version: 3.1.0(acorn@8.14.1)
@@ -268,6 +271,9 @@ importers:
       use-composed-ref:
         specifier: ^1.4.0
         version: 1.4.0(@types/react@18.3.20)(react@18.3.1)
+      valibot:
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.8.3)
       vfile:
         specifier: ^6.0.3
         version: 6.0.3
@@ -457,6 +463,10 @@ packages:
     resolution: {integrity: sha512-/tY4cU7Mq6YAxs5cG3ZaLYJfH3k8rmn4kEHw9Yn4lxdPUOQhVyAe1wrqr6+jakWCiZJRFKszcUSH1/M5BkzPeA==}
     peerDependencies:
       typescript: '>=5.8'
+
+  '@acdh-oeaw/validate-env@0.0.3':
+    resolution: {integrity: sha512-dP7ZGC533M/Hfebriu5THBQt9DXOuldywY0U5893JMBuAXrGr5f+ONuDE5tk5zp5XHu2Lks+VDkg2wX+TQ03ow==}
+    engines: {node: '>=20', pnpm: '>=9'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -4856,6 +4866,14 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  valibot@1.0.0:
+    resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vfile-location@4.1.0:
     resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}
 
@@ -5019,6 +5037,8 @@ snapshots:
   '@acdh-oeaw/tsconfig@1.5.1(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
+
+  '@acdh-oeaw/validate-env@0.0.3': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -10822,6 +10842,10 @@ snapshots:
       diff: 5.2.0
       kleur: 4.1.5
       sade: 1.8.1
+
+  valibot@1.0.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
 
   vfile-location@4.1.0:
     dependencies:


### PR DESCRIPTION
this adds environment variable validation with valibot. a validation schema is defined in config/env.config.ts.

also, a lint rule enforces importing from env.config.ts instead of reading from process.env directly.