### PR TITLE
fix: rewrite redirect_uri to use x-forwarded-host

### DIFF
--- a/app/(cms)/api/keystatic/[...params]/route.ts
+++ b/app/(cms)/api/keystatic/[...params]/route.ts
@@ -1,5 +1,14 @@
 import { makeRouteHandler } from "@keystatic/next/route-handler";
 
 import config from "@/config/keystatic.config";
+import { rewriteUrl } from "@/lib/keystatic/rewrite-url";
 
-export const { POST, GET } = makeRouteHandler({ config });
+const { GET: _GET, POST: _POST } = makeRouteHandler({ config });
+
+export function GET(request: Request) {
+	return _GET(rewriteUrl(request));
+}
+
+export function POST(request: Request) {
+	return _POST(rewriteUrl(request));
+}


### PR DESCRIPTION
the github oauth flow initiated by keystatic uses the k8s-internal domain name, which means the oauth flow fails.

this adds rewrites to the keystatic api routes to check x-forwarded-host headers if available and use those instead.