### PR TITLE
fix: fix link field validation when optional

### DIFF
--- a/lib/keystatic/create-link-schema.ts
+++ b/lib/keystatic/create-link-schema.ts
@@ -20,11 +20,11 @@ export function createLinkSchema(paths: Paths) {
 				}),
 				search: fields.text({
 					label: "Query params",
-					validation: { isRequired: false, pattern: validation.urlSearchParams },
+					validation: { isRequired: false, pattern: validation.urlSearchParamsOptional },
 				}),
 				hash: fields.text({
 					label: "URL fragment",
-					validation: { isRequired: false, pattern: validation.urlFragment },
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
 				}),
 			}),
 			"contribute-pages": fields.object({
@@ -35,21 +35,21 @@ export function createLinkSchema(paths: Paths) {
 				}),
 				search: fields.text({
 					label: "Query params",
-					validation: { isRequired: false, pattern: validation.urlSearchParams },
+					validation: { isRequired: false, pattern: validation.urlSearchParamsOptional },
 				}),
 				hash: fields.text({
 					label: "URL fragment",
-					validation: { isRequired: false, pattern: validation.urlFragment },
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
 				}),
 			}),
 			"contact-page": fields.object({
 				search: fields.text({
 					label: "Query params",
-					validation: { isRequired: false, pattern: validation.urlSearchParams },
+					validation: { isRequired: false, pattern: validation.urlSearchParamsOptional },
 				}),
 				hash: fields.text({
 					label: "URL fragment",
-					validation: { isRequired: false, pattern: validation.urlFragment },
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
 				}),
 			}),
 			"current-page": fields.text({
@@ -72,11 +72,11 @@ export function createLinkSchema(paths: Paths) {
 			"search-page": fields.object({
 				search: fields.text({
 					label: "Query params",
-					validation: { isRequired: false, pattern: validation.urlSearchParams },
+					validation: { isRequired: false, pattern: validation.urlSearchParamsOptional },
 				}),
 				hash: fields.text({
 					label: "URL fragment",
-					validation: { isRequired: false, pattern: validation.urlFragment },
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
 				}),
 			}),
 		},

--- a/lib/keystatic/validation.ts
+++ b/lib/keystatic/validation.ts
@@ -6,8 +6,21 @@
 
 export const email = { regex: /.+?@.+?/, message: "Must be a valid email address." };
 
-export const twitter = { regex: /^@.+/, message: "Must start with an '@' character." };
+export const twitter = { regex: /^@.+/, message: "Must include the leading '@' character." };
 
-export const urlFragment = { regex: /^#.+/, message: "Must start with '#' character." };
+export const urlFragment = { regex: /^#.+/, message: "Must include the leading '#' character." };
 
-export const urlSearchParams = { regex: /^\?.+/, message: "Must start with '?' character." };
+export const urlSearchParams = {
+	regex: /^\?.+/,
+	message: "Must include the leading '?' character.",
+};
+
+export const urlFragmentOptional = {
+	regex: /^$|^#.+/,
+	message: "Must include the leading '#' character.",
+};
+
+export const urlSearchParamsOptional = {
+	regex: /^$|^\?.+/,
+	message: "Must include the leading '?' character.",
+};


### PR DESCRIPTION
this fixes the validation schema for the cms `<Link>` widget: when provising a regex pattern on an optional field, keystatic will *only* use the regex pattern, so we need to make sure that empty values are included in the regex.