### PR TITLE
build: disable image optimisation to see if it helps with memory pressure

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,6 +49,7 @@ const config: NextConfig = {
 	},
 	images: {
 		remotePatterns: [new URL(env.NEXT_PUBLIC_API_BASE_URL)],
+		unoptimized: true,
 	},
 	output: "standalone",
 	poweredByHeader: false,


### PR DESCRIPTION
see https://github.com/SSHOC/sshoc-marketplace-backend/issues/498#issuecomment-2966639025

this globally disables image optimization, to see if it helps with memory consumption in our deployment. if yes, that would be a helpful data point to investigate further.