### PR TITLE
Revert "build: disable image optimisation to see if it helps with memory pressure (#291)"

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,7 +49,6 @@ const config: NextConfig = {
 	},
 	images: {
 		remotePatterns: [new URL(env.NEXT_PUBLIC_API_BASE_URL)],
-		unoptimized: true,
 	},
 	output: "standalone",
 	poweredByHeader: false,


### PR DESCRIPTION
This reverts commit fdeecbeb278df048d786d3173a87517a0f3d26b3.

The memory issue seems to not be related to image optimisation.