### PR TITLE
build: switch from alpine to slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@
 # using alpine base image to avoid `sharp` memory leaks.
 # @see https://sharp.pixelplumbing.com/install#linux-memory-allocator
 
+# FIXME: temporarily switching to glibc based image, to investigate memory issues
+# image optimisation is also disabled temporarily
+
 # build
-FROM node:22-alpine AS build
+FROM node:22-slim AS build
 
 RUN corepack enable
 
@@ -59,7 +62,7 @@ RUN --mount=type=secret,id=KEYSTATIC_GITHUB_CLIENT_ID,uid=1000 \
 		pnpm run build
 
 # serve
-FROM node:22-alpine AS serve
+FROM node:22-slim AS serve
 
 RUN mkdir /app && chown -R node:node /app
 WORKDIR /app


### PR DESCRIPTION
investigating steady increase in memory consumption, which can be observed in rancher and which leads to regular container restarts caused by OOM.

we are definitely leaking sockets - `lsof -p 1 | wc -l` showed up to a million!

running a frontend container locally, it looks as if this issue does not occur when switching from `alpine` to a regular `glibc` based `node` image. testing that theory with this PR.

since image optimisation is still disabled we should not run into memory issues caused by `sharp`, which is the actual reason we are using `alpine` images.