### PR TITLE
ci: switch to deployment app

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -14,7 +14,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-deploy:
+  build:
+    name: Build docker images
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -22,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -36,14 +37,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker (production)
         id: meta-production
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-main
           tags: |
             type=raw,value=main
 
       - name: Build and push Docker image (production)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -70,23 +71,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to cluster (production)
-        uses: acdh-oeaw/deploy-action@v1
-        with:
-          token: ${{ secrets.RANCHER_API_TOKEN }}
-          project: c-m-6hwgqq2g:p-jv25s
-          deployment: sshoc-marketplace-frontend:sshoc-mp-frontend
-
       - name: Extract metadata (tags, labels) for Docker (stage)
         id: meta-stage
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-stage
           tags: |
             type=raw,value=stage
 
       - name: Build and push Docker image (stage)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -112,23 +106,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to cluster (stage)
-        uses: acdh-oeaw/deploy-action@v1
-        with:
-          token: ${{ secrets.RANCHER_API_TOKEN }}
-          project: c-m-6hwgqq2g:p-jv25s
-          deployment: sshoc-marketplace-frontend:sshoc-mp-frontendstg
-
       - name: Extract metadata (tags, labels) for Docker (dev)
         id: meta-dev
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dev
           tags: |
             type=raw,value=dev
 
       - name: Build and push Docker image (dev)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -154,9 +141,43 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to cluster (dev)
-        uses: acdh-oeaw/deploy-action@v1
-        with:
-          token: ${{ secrets.RANCHER_API_TOKEN }}
-          project: c-m-6hwgqq2g:p-jv25s
-          deployment: sshoc-marketplace-frontend:sshoc-mp-frontenddev
+  deploy:
+    name: Deploy docker images
+    needs: [build]
+    uses: sshoc/gl-autodevops-minimal-port/.github/workflows/deploy.yml@main
+    secrets: inherit
+
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - name: dev
+            tag: dev
+            environment: development
+            public_url: https://sshoc-marketplace-api.acdh-dev.oeaw.ac.at
+            service_id: 15819
+            domain: acdh-dev.oeaw.ac.at
+          - name: stage
+            tag: stage
+            environment: staging
+            public_url: https://sshoc-marketplace-api-stage.acdh-dev.oeaw.ac.at
+            service_id: 19194
+            domain: acdh-dev.oeaw.ac.at
+          - name: main
+            tag: main
+            environment: production
+            public_url: https://marketplace-api.sshopencloud.eu
+            service_id: 17467
+            domain: sshopencloud.eu
+      max-parallel: 1
+
+    with:
+      default_port: "3000"
+      environment: "${{ matrix.target.environment }}"
+      APP_NAME: "${{ matrix.target.name }}"
+      APP_ROOT: "/"
+      DOCKER_TAG: "ghcr.io/${{ github.repository }}-${{ matrix.target.tag }}"
+      PUBLIC_URL: "${{ matrix.target.public_url }}"
+      SERVICE_ID: "${{ matrix.target.service_id }}"
+      KUBE_NAMESPACE: "sshoc-marketplace-frontend"
+      KUBE_INGRESS_BASE_DOMAIN: "${{ matrix.target.domain }}"


### PR DESCRIPTION
dont really want to do this urgently, but immediate motivation is that rancher pulls stale images (i.e. when pulling main tag, the sha that gets listed in the pod is not the latest main)